### PR TITLE
bpftune: packaging support

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -43,7 +43,7 @@ ifeq ($(BPFTUNE_VERSION),)
 BPFTUNE_VERSION := $(KERNEL_REL)
 endif
 
-VERSION = 0.1.1
+VERSION = 0.1.2
 VERSION_SCRIPT  := libbpftune.map
 
 CFLAGS = -fPIC -Wall -Wextra -march=native -g -I../include -std=c99


### PR DESCRIPTION
bump to 0.1-2 after package review.

Orabug: 35385703


Reviewed-by: Laurence Rochfort <laurence.rochfort@oracle.com>