### PR TITLE
sample_[legacy_]test should "make clean" before building sample

### DIFF
--- a/test/sample_legacy_test.sh
+++ b/test/sample_legacy_test.sh
@@ -37,7 +37,7 @@ rm -f /usr/local/lib64/bpftune/sample_tuner.so
 sleep 1
 test_run_cmd_local "$BPFTUNE -dsL &" true
 sleep $SETUPTIME
-cd ../sample_tuner ; make install
+cd ../sample_tuner ; make clean; make install
 sleep $SLEEPTIME
 # trigger event
 sysctl kernel.core_pattern

--- a/test/sample_test.sh
+++ b/test/sample_test.sh
@@ -37,7 +37,7 @@ rm -f /usr/local/lib64/bpftune/sample_tuner.so
 sleep 1
 test_run_cmd_local "$BPFTUNE -ds &" true
 sleep $SETUPTIME
-cd ../sample_tuner ; make install
+cd ../sample_tuner ; make clean; make install
 sleep $SLEEPTIME
 # trigger event
 sysctl kernel.core_pattern


### PR DESCRIPTION
...since an old version of sample_tuner.so could be present.