### PR TITLE
bpftune: fix library search issues on Ubuntu

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -31,11 +31,18 @@ INCLUDES := -I../include -I$(BPF_INCLUDE) -I$(NL_INCLUDE) -I../include/uapi
 
 INSTALL ?= install
 
-DESTDIR ?=
+DESTDIR ?= /
 prefix ?= /usr
 installprefix = $(DESTDIR)/$(prefix)
 
 INSTALLPATH = $(installprefix)
+
+# Prefix path can be /usr, /usr/local or for packaging case
+# /path2rpmbuilddir/usr[/local]. We use the /usr path as a guide
+# to where to bisect the full path such that everything prior to
+# it is considered to be prefix to config path /etc.
+confprefix ?= $(shell echo $(prefix) | awk -F /usr '{ printf $1 "/etc" }')
+CONFPATH = $(DESTDIR)/$(confprefix)/ld.so.conf.d
 
 KERNEL_REL := $(shell uname -r)
 
@@ -117,6 +124,8 @@ install: $(OPATH)libbpftune.so $(OPATH)bpftune bpftune.service
 	$(INSTALL) -m 644 bpftune.service $(installprefix)/lib/systemd/system
 	$(INSTALL) -m 0755 -d $(INSTALLPATH)/lib64/bpftune
 	$(INSTALL) $(TUNER_LIBS) $(INSTALLPATH)/lib64/bpftune
+	echo $(prefix)/lib64 > $(CONFPATH)/libbpftune.conf
+	if [ $(DESTDIR) =  / ]; then ldconfig; fi
 
 $(OPATH)bpftune: bpftune.c $(OPATH)bpftune.o $(OPATH)libbpftune.so
 	$(QUIET_LINK)$(CC) $(CFLAGS) $(OPATH)bpftune.o -o $@ \

--- a/test/cap_test.sh
+++ b/test/cap_test.sh
@@ -36,10 +36,14 @@ for BPFTUNECMD in "$BPFTUNE &" "service bpftune start" ; do
 
   sleep $SETUPTIME
 
-  caps=$(getpcaps $(pgrep bpftune) 2>&1 | \
-         awk '/cap_net_admin,cap_sys_chroot,cap_sys_admin,cap_syslog[+=]p/ { print $0 }')
+  caps=$(getpcaps $(pgrep bpftune) 2>&1)
+#         awk '/[+=]p/ { print $0 }')
 
   echo "caps: $caps"
+
+  for cap in cap_net_admin cap_sys_module cap_sys_chroot cap_sys_admin cap_syslog ; do
+    echo $caps | grep -E $cap >/dev/null
+  done
 
   if [[ -n "$caps" ]]; then
     test_pass

--- a/test/log_test.sh
+++ b/test/log_test.sh
@@ -37,11 +37,11 @@ for MODE in debug info syslog service; do
    syslog)
 	OPTIONS="-d"
 	BPFTUNECMD="$BPFTUNE $OPTIONS &"
-	LOGFILE=/var/log/messages
+	LOGFILE=$SYSLOGFILE
 	;;
    service)
 	BPFTUNECMD="service bpftue start"
-	LOGFILE=/var/log/messages
+	LOGFILE=$SYSLOGFILE
 	;;
    *)
 	OPTIONS="-s"

--- a/test/service_test.sh
+++ b/test/service_test.sh
@@ -27,7 +27,7 @@
 SLEEPTIME=1
 
 
-LOGFILE=/var/log/messages
+LOGFILE=$SYSLOGFILE
 
 test_start "$0|service test: does enabling the service work?"
 

--- a/test/test_lib.sh
+++ b/test/test_lib.sh
@@ -60,7 +60,11 @@ check_prog "$IPERF3" iperf3 iperf3
 export QPERF=$(which qperf 2>/dev/null)
 export FIREWALL_CMD=$(which firewall-cmd 2>/dev/null)
 export AUDIT_CMD=$(which auditctl 2>/dev/null)
-export LOGFILE=${LOGFILE:-"/var/log/messages"}
+export SYSLOGFILE=${SYSLOGFILE:-"/var/log/messages"}
+if [[ ! -f $SYSLOGFILE ]]; then
+	export SYSLOGFILE="/var/log/syslog"
+fi
+export LOGFILE=$SYSLOGFILE
 export BPFTUNE_LEGACY=${BPFTUNE_LEGACY:-0}
 export BPFTUNE_NETNS=${BPFTUNE_NETNS:-1}
 


### PR DESCRIPTION
add ld.so.conf.d file for /usr/lib64 for bpftune.
also fix issues with tests for ubuntu such as assuming messages are in /var/log/messages (it's syslog for ubuntu)

Reported-by: https://github.com/twirrim

should resolve https://github.com/oracle-samples/bpftune/issues/11#top