### PR TITLE
tcp_cong_tuner: add tcp_iter + getsockopt() test in probe program

### DIFF
--- a/src/tcp_cong_tuner.bpf.c
+++ b/src/tcp_cong_tuner.bpf.c
@@ -21,8 +21,6 @@
 
 #include "tcp_cong_tuner.h"
 
-#define CONG_MAXNAME	16
-
 struct remote_host {
 	__u64 last_retransmit;
 	__u64 retransmits;

--- a/src/tcp_cong_tuner.h
+++ b/src/tcp_cong_tuner.h
@@ -28,6 +28,8 @@ enum tcp_cong_scenarios {
 	TCP_CONG_HTCP,
 };
 
+#define CONG_MAXNAME	16
+
 /* a long fat pipe is defined as having a BDP of > 10^5; it implies latency
  * plus high bandwith.  In such cases use htcp.
  */


### PR DESCRIPTION
support for tcp iter with getsockopt() was added in 5.9, 5.14 respectively, so include test that getsockopt() works in iter context to ensure we do not need legacy mode.