### PR TITLE
Status return

### DIFF
--- a/sample_tuner/sample_tuner.c
+++ b/sample_tuner/sample_tuner.c
@@ -24,8 +24,7 @@
 
 int init(struct bpftuner *tuner)
 {
-	bpftuner_bpf_init(sample, tuner, NULL);
-	return 0;
+	return bpftuner_bpf_init(sample, tuner, NULL);
 }
 
 void fini(struct bpftuner *tuner)

--- a/src/neigh_table_tuner.c
+++ b/src/neigh_table_tuner.c
@@ -57,7 +57,10 @@ static struct bpftunable_scenario scenarios[] = {
 
 int init(struct bpftuner *tuner)
 {
-	bpftuner_bpf_init(neigh_table, tuner, NULL);
+	int err = bpftuner_bpf_init(neigh_table, tuner, NULL);
+
+	if (err)
+		return err;
 	return bpftuner_tunables_init(tuner, ARRAY_SIZE(descs), descs,
 				      ARRAY_SIZE(scenarios), scenarios);
 }

--- a/src/net_buffer_tuner.c
+++ b/src/net_buffer_tuner.c
@@ -28,14 +28,21 @@ static struct bpftunable_scenario scenarios[] = {
 int init(struct bpftuner *tuner)
 {
 	long cpu_bitmap = 0;
+	int err;
 
 	bpftune_sysctl_read(0, "net.core.flow_limit_cpu_bitmap", &cpu_bitmap);
 
-	bpftuner_bpf_open(net_buffer, tuner);
-	bpftuner_bpf_load(net_buffer, tuner);
+	err = bpftuner_bpf_open(net_buffer, tuner);
+	if (err)
+		return err;
+	err = bpftuner_bpf_load(net_buffer, tuner);
+	if (err)
+		return err;
 	bpftuner_bpf_var_set(net_buffer, tuner, flow_limit_cpu_bitmap,
 			     cpu_bitmap);
-	bpftuner_bpf_attach(net_buffer, tuner, NULL);
+	err = bpftuner_bpf_attach(net_buffer, tuner, NULL);
+	if (err)
+		return err;
 
 	return bpftuner_tunables_init(tuner, NET_BUFFER_NUM_TUNABLES, descs,
 				      ARRAY_SIZE(scenarios), scenarios);

--- a/src/netns_tuner.c
+++ b/src/netns_tuner.c
@@ -39,13 +39,20 @@ static struct bpftunable_scenario scenarios[] = {
 int init(struct bpftuner *tuner)
 {
 	const char *optionals[] = { "entry__net_free", NULL };
+	int err;
 
 	if (!bpftune_netns_cookie_supported())
 		return -ENOTSUP;
 
-	bpftuner_bpf_open(netns, tuner);
-	bpftuner_bpf_load(netns, tuner);
-	bpftuner_bpf_attach(netns, tuner, optionals);
+	err = bpftuner_bpf_open(netns, tuner);
+	if (err)
+		return err;
+	err = bpftuner_bpf_load(netns, tuner);
+	if (err)
+		return err;
+	err = bpftuner_bpf_attach(netns, tuner, optionals);
+	if (err)
+		return err;
 
 	return bpftuner_tunables_init(tuner, ARRAY_SIZE(descs), descs,
 				      ARRAY_SIZE(scenarios), scenarios);

--- a/src/route_table_tuner.c
+++ b/src/route_table_tuner.c
@@ -37,9 +37,10 @@ static struct bpftunable_scenario scenarios[] = {
 
 int init(struct bpftuner *tuner)
 {
-	bpftuner_bpf_open(route_table, tuner);
-	bpftuner_bpf_load(route_table, tuner);
-	bpftuner_bpf_attach(route_table, tuner, NULL);
+	int err = bpftuner_bpf_init(route_table, tuner, NULL);
+
+	if (err)
+		return err;
 	return bpftuner_tunables_init(tuner, ARRAY_SIZE(descs), descs,
 				      ARRAY_SIZE(scenarios), scenarios);
 }

--- a/src/sysctl_tuner.c
+++ b/src/sysctl_tuner.c
@@ -33,8 +33,10 @@ extern unsigned short learning_rate;
 
 int init(struct bpftuner *tuner)
 {
-	bpftuner_bpf_init(sysctl, tuner, NULL);
+	int err = bpftuner_bpf_init(sysctl, tuner, NULL);
 
+	if (err)
+		return err;
 	/* attach to root cgroup */
 	if (bpftuner_cgroup_attach(tuner, "sysctl_write", BPF_CGROUP_SYSCTL))
 		return 1;

--- a/src/tcp_buffer_tuner.c
+++ b/src/tcp_buffer_tuner.c
@@ -139,9 +139,14 @@ retry:
 int init(struct bpftuner *tuner)
 {
 	int pagesize;
+	int err;
 
-	bpftuner_bpf_open(tcp_buffer, tuner);
-	bpftuner_bpf_load(tcp_buffer, tuner);
+	err = bpftuner_bpf_open(tcp_buffer, tuner);
+	if (err)
+		return err;
+	err = bpftuner_bpf_load(tcp_buffer, tuner);
+	if (err)
+		return err;
 
 	pagesize = sysconf(_SC_PAGESIZE);
 	if (pagesize < 0)
@@ -154,7 +159,9 @@ int init(struct bpftuner *tuner)
 			     ilog2(SK_MEM_QUANTUM));
 	bpftuner_bpf_var_set(tcp_buffer, tuner, nr_free_buffer_pages,
 			     nr_free_buffer_pages(true));
-	bpftuner_bpf_attach(tcp_buffer, tuner, NULL);
+	err = bpftuner_bpf_attach(tcp_buffer, tuner, NULL);
+	if (err)
+		return err;
 	return bpftuner_tunables_init(tuner, TCP_BUFFER_NUM_TUNABLES, descs,
 				      ARRAY_SIZE(scenarios), scenarios);
 }

--- a/src/tcp_cong_tuner.c
+++ b/src/tcp_cong_tuner.c
@@ -55,7 +55,9 @@ int init(struct bpftuner *tuner)
 		bpftune_log(LOG_DEBUG, "could not load tcp_bbr module: %s\n",
 			    strerror(-err));
 
-	bpftuner_bpf_init(tcp_cong, tuner, NULL);
+	err = bpftuner_bpf_init(tcp_cong, tuner, NULL);
+	if (err)
+		return err;
 
 	err = bpftune_cap_add();
 	if (err) {


### PR DESCRIPTION
bpftune bpf initialization steps in macros in libbpftune.h (macros being used since bpf skeletons use object names in data structures) need to return status as without that we drive on if open/load/attach fail and this can trigger segmentation faults.