### PR TITLE
bpftune: enable -Wall for clang compilation and fix issues

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -26,7 +26,7 @@ LLC ?= llc
 LLVM_STRIP ?= llvm-strip
 BPFTOOL ?= bpftool
 BPF_INCLUDE := /usr/include
-BPF_CFLAGS := -g -fno-stack-protector
+BPF_CFLAGS := -g -fno-stack-protector -Wall
 NL_INCLUDE := /usr/include/libnl3
 INCLUDES := -I../include -I$(BPF_INCLUDE) -I$(NL_INCLUDE) -I../include/uapi
 

--- a/src/netns_tuner.bpf.c
+++ b/src/netns_tuner.bpf.c
@@ -39,7 +39,6 @@ SEC("kretprobe/setup_net")
 int BPF_KRETPROBE(bpftune_setup_net_return, int ret)
 {
 	struct bpftune_event event = {};
-	__u64 current, *netnsp;
 	struct net *netns;
 	
 	if (ret != 0)

--- a/src/route_table_tuner.bpf.c
+++ b/src/route_table_tuner.bpf.c
@@ -31,7 +31,7 @@ SEC("kprobe/fib6_run_gc")
 int BPF_KPROBE(bpftune_fib6_run_gc_entry, unsigned long expires,
 					  struct net *net, bool force)
 {
-	struct dst_net *dst_netp, dst_net = {};
+	struct dst_net *dst_netp;
 
 	get_entry_struct(dst_net_map, dst_netp);
 	/* already in gc, skip */

--- a/src/sysctl_tuner.bpf.c
+++ b/src/sysctl_tuner.bpf.c
@@ -36,7 +36,7 @@ int BPF_KPROBE(bpftune_sysctl, struct ctl_table_header *head,
 	struct bpftune_event event = {};
 	struct ctl_dir *root, *parent, *gparent, *ggparent;
 	struct ctl_dir *gggparent;
-	struct ctl_table *tbl, *parent_table;
+	struct ctl_table *parent_table;
 	int len = sizeof(event.str);
 	const char *procname;
 	int current_pid = 0;	
@@ -81,8 +81,6 @@ int BPF_KPROBE(bpftune_sysctl, struct ctl_table_header *head,
 		procname = BPF_CORE_READ(parent_table, procname);
 		if (procname) {
 			if (!bpf_probe_read(event.str, sizeof(event.str), procname)) {
-				int i;
-
 				for (; len > 0 && *str; len--, str++) {}
 				if (len == 0)
 					return 0;


### PR DESCRIPTION
fix unused variable warnings

Suggested-by: https://github.com/pavlinux