### PR TITLE
add multiple strategy support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,12 +35,15 @@ INSTALLPATH = $(installprefix)
 
 .PHONY: all clean
 
-all: srcdir docdir
+all: srcdir docdir testdir
 	
 srcdir:
 	cd src; make
 docdir:
 	cd docs; make man
+
+testdir: srcdir
+	cd test; make
 
 test:	FORCE
 	cd test; make test
@@ -55,7 +58,7 @@ pkg:    all
 
 FORCE:
 	
-clean: srcclean docclean
+clean: srcclean docclean testclean
 
 distclean: clean distclean_src
 	
@@ -65,6 +68,8 @@ docclean:
 	cd docs; make clean
 distclean_src:
 	cd src; make distclean
+testclean:
+	cd test; make clean
 
 install: srcinstall includeinstall docinstall
 	

--- a/README.md
+++ b/README.md
@@ -93,14 +93,33 @@ The key components are
   from BPF programs to userspace via the shared ring buffer.
   Each tuner has an associated set of tunables that it manages.
 
+- optional strategies: a tuner can specify multiple strategies;
+  after running for a while a strategy times out and we assess
+  if a better strategy is available.  Each strategy specifies a
+	- name
+	- description
+	- timeout	
+	- evaluation function
+	- set of BPF program names in tuner associated with strategy
+
+  Strategies are optional and should be set in the tuner init()
+  method via bpftune_strategies_add().  See test/strategy
+  for a coded example.  When a strategy times out, the various
+  evaluation functions are called and the highest-value evaluation
+  dictates the next stratgey.
+
+  Strategies provide a way of providing multiple schemes for
+  auto-tuning the same set of tunables, where the choice is
+  guided by an evaluation of the effectiveness of the strategies.
+
 - events specify a
 	- tuner id: which tuner the event is destined for
 	- a scenario: what happened
 	- an associated netns (if supported)
 	- information about the event (IP address etc)
 
-- the tuner then responds to the event with a strategy; increase
-  or decrease a tunable value, etc.  Describing the event
+- the tuner then responds to the event guided by the active strategy;
+  increase or decrease a tunable value, etc.  Describing the event
   in the log is key; this allows an admin to understand what
   changed and why.
 
@@ -179,6 +198,12 @@ To build the following packages are needed (names may vary by distro);
 - clang >= 11
 - llvm >= 11
 - python3-docutils
+
+From the kernel side, the kernel needs to support BPF ring buffer
+(around the 5.6 kernel, though 5.4 is supported on Oracle Linux
+as ring buffer support was backported), and kernel BTF is
+required (CONFIG_DEBUG_INFO_BTF=y).  Verify /sys/kernel/btf/vmlinux
+is present.
 
 To enable bpftune as a service
 

--- a/include/bpftune/bpftune.h
+++ b/include/bpftune/bpftune.h
@@ -138,6 +138,18 @@ struct bpftuner_netns {
 	enum bpftune_state state;
 };
 
+struct bpftuner;
+
+struct bpftuner_strategy {
+	const char *name;
+	const char *description;
+	/* return a number to compare with other strategies */
+	int (*evaluate)(struct bpftuner *tuner, struct bpftuner_strategy *strategy);
+	unsigned long timeout;	/* time in seconds until evaluation */
+	const char **bpf_progs;	/* programs to load in BPF skeleton for this
+				 * strategy; if NULL, all */
+};
+
 struct bpftuner {
 	unsigned int id;
 	enum bpftune_state state;
@@ -151,6 +163,8 @@ struct bpftuner {
 	void *obj;
 	int (*init)(struct bpftuner *tuner);
 	void (*fini)(struct bpftuner *tuner);
+	struct bpftuner_strategy **strategies;
+	struct bpftuner_strategy *strategy;
 	void *ring_buffer_map;
 	int ring_buffer_map_fd;
 	void *corr_map;

--- a/include/bpftune/libbpftune.h
+++ b/include/bpftune/libbpftune.h
@@ -111,6 +111,9 @@ static inline const char *bpftuner_tunable_name(struct bpftuner *tuner,
 #define bpftuner_for_each_tunable(tuner, tunable)			     \
 	for (unsigned int __itun = 0; (tunable = bpftuner_tunable(tuner, __itun)); __itun++)
 
+#define bpftuner_for_each_strategy(tuner, strategy)			     \
+	for (unsigned int __s = 0; (strategy = tuner->strategies[__s]); __s++)
+
 int bpftuner_tunable_sysctl_write(struct bpftuner *tuner,
 				  unsigned int tunable,
 				  unsigned int scenario,
@@ -168,6 +171,7 @@ void bpftuner_tunables_fini(struct bpftuner *tuner);
 			tuner->ring_buffer_map = __lskel->maps.ring_buffer_map;\
 			tuner->netns_map = __lskel->maps.netns_map;	     \
 		}							     \
+		bpftuner_bpf_set_autoload(tuner);			     \
 	} while (0);							     \
 	bpftune_cap_drop();						     \
 	if (__err) {							     \
@@ -290,5 +294,11 @@ int bpftuner_netns_fd_from_cookie(struct bpftuner *tuner, unsigned long cookie);
 
 int bpftune_module_load(const char *name);
 int bpftune_module_unload(const char *name);
+
+int bpftuner_strategy_set(struct bpftuner *tuner, struct bpftuner_strategy *strategy);
+int bpftuner_strategies_add(struct bpftuner *tuner, struct bpftuner_strategy **strategies,
+			    struct bpftuner_strategy *default_strategy);
+bool bpftuner_bpf_prog_in_strategy(struct bpftuner *tuner, const char *prog);
+void bpftuner_bpf_set_autoload(struct bpftuner *tuner);
 
 #endif /* __LIBBPFTUNE_H */

--- a/src/Makefile
+++ b/src/Makefile
@@ -59,7 +59,7 @@ CFLAGS = -fPIC -Wall -Wextra -march=native -g -I../include -std=c99
 
 CFLAGS += -DBPFTUNE_VERSION='"$(BPFTUNE_VERSION)"' $(INCLUDES)
 
-LDLIBS = -lbpf -ldl -lm -lcap -lnl-3 -lpthread -lnl-route-3
+LDLIBS = -lbpf -ldl -lm -lrt -lcap -lnl-3 -lpthread -lnl-route-3
 
 LDFLAGS += -L. -L/usr/local/lib64
 

--- a/src/libbpftune.map
+++ b/src/libbpftune.map
@@ -32,6 +32,8 @@ LIBBPFTUNE_0.1.1 {
 		bpftuner_tunable_update;
 		bpftuner_fini;
 		bpftuner_bpf_fini;
+		bpftuner_bpf_set_autoload;
+		bpftuner_bpf_prog_in_strategy;
 		bpftuner_tunables_fini;
 		bpftune_netns_cookie_supported;
 		bpftuner_netns_init;
@@ -39,6 +41,8 @@ LIBBPFTUNE_0.1.1 {
 		bpftuner_netns_from_cookie;
 		bpftuner_netns_fd_from_cookie;
 	        bpftuner_ring_buffer_map_fd;
+		bpftuner_strategy_set;
+		bpftuner_strategies_add;
 		bpftune_ring_buffer_init;
 		bpftune_ring_buffer_poll;
 		bpftune_ring_buffer_fini;

--- a/test/Makefile
+++ b/test/Makefile
@@ -17,10 +17,12 @@
 # Boston, MA 021110-1307, USA.
 #
 
+
 PERF_TESTS = iperf3_test qperf_test
 
 TUNER_TESTS =	support_test log_test service_test inotify_test cap_test \
 		sample_test sample_legacy_test \
+		strategy_test strategy_legacy_test \
 		sysctl_test sysctl_legacy_test sysctl_netns_test \
 		netns_test netns_legacy_test \
 		backlog_test backlog_legacy_test \
@@ -53,14 +55,20 @@ INSTALLPATH = $(installprefix)/lib/tcptune_test/
 install_sh_PROGRAM = install
 install_sh_DIR = install -dv
 
-all: $(PROGS)
+all: strategydir $(PROGS)
 	
+strategydir:
+	cd strategy; make
+
 PHONY: clean
 	
-clean:
+clean: strategyclean
 	rm -f $(PROGS)
 
-test: $(TESTS)
+strategyclean:
+	cd strategy; make clean
+
+test: all $(TESTS)
 	
 test_perf: $(PERF_TESTS)
 

--- a/test/strategy/Makefile
+++ b/test/strategy/Makefile
@@ -1,0 +1,95 @@
+# SPDX-License-Identifier: GPL-2.0 WITH Linux-syscall-note
+#
+# Copyright (c) 2023, Oracle and/or its affiliates.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public
+# License v2 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public
+# License along with this program; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 021110-1307, USA.
+#
+
+SRCARCH := $(shell uname -m | sed -e s/i.86/x86/ -e s/x86_64/x86/ \
+				  -e /arm64/!s/arm.*/arm/ -e s/sa110/arm/ \
+				  -e s/aarch64.*/arm64/ )
+
+CLANG ?= clang
+LLC ?= llc
+LLVM_STRIP ?= llvm-strip
+BPFTOOL ?= bpftool
+BPF_INCLUDE := ../../include
+NL_INCLUDE := /usr/include/libnl3
+INCLUDES := -I$(BPF_INCLUDE) -I$(NL_INCLUDE) -I/usr/include/uapi
+
+INSTALL ?= install
+
+DESTDIR ?=
+prefix ?= /usr
+installprefix = $(DESTDIR)/$(prefix)
+
+INSTALLPATH = $(installprefix)
+
+CFLAGS = -fPIC -Wall -Wextra -march=native -g -I../include -std=c99
+
+CFLAGS += -DBPFTUNE_VERSION='"$(BPFTUNE_VERSION)"' $(INCLUDES)
+
+LDLIBS = -lbpf -ldl -lm -lcap -lpthread
+
+LDFLAGS += -L../../src -L/usr/local/lib64
+
+ifeq ($(V),1)
+Q =
+else
+Q = @
+MAKEFLAGS += --no-print-directory
+submake_extras := feature_display=0
+endif
+
+TUNERS = strategy_tuner
+
+TUNER_OBJS = $(patsubst %,%.o,$(TUNERS))
+TUNER_LIBS = $(patsubst %,%.so,$(TUNERS))
+
+BPF_TUNERS = $(patsubst %,%.bpf.o,$(TUNERS))
+
+BPF_OBJS = $(BPF_TUNERS)
+
+BPF_SKELS = $(patsubst %,%.skel.h,$(TUNERS))
+
+.DELETE_ON_ERROR:
+
+.PHONY: clean
+
+all: $(TUNER_LIBS)
+	
+clean:
+	$(Q)$(RM) *.o *.d *.so*
+	$(Q)$(RM) *.skel*.h
+	$(Q)$(RM) -r .output
+
+$(TUNER_LIBS): $(BPF_SKELS) $(TUNER_OBJS)
+	$(CC) $(CFLAGS) -shared -o $(@) $(patsubst %.so,%.c,$(@)) \
+		$(LDLIBS) -lbpftune $(LDFLAGS)
+
+%.skel.h: %.bpf.o
+	$(QUIET_GEN)$(BPFTOOL) gen skeleton $< > $@
+
+$(BPF_OBJS): $(patsubst %.o,%.c,$(BPF_OBJS))
+	$(CLANG) -g -D__TARGET_ARCH_$(SRCARCH) -O2 -target bpf			\
+		$(INCLUDES) -c $(patsubst %.o,%.c,$(@)) -o $(@);
+	$(CLANG) -g -D__TARGET_ARCH_$(SRCARCH) -DBPFTUNE_LEGACY -O2 -target bpf \
+		$(INCLUDES) -c $(patsubst %.o,%.c,$(@)) \
+		-o $(patsubst %.o,%.legacy.o,$(@))
+
+$(BPF_SKELS): $(BPF_OBJS)
+	$(BPFTOOL) gen skeleton $(subst .skel.h,.bpf.o,$@) > $@ ;\
+	$(BPFTOOL) gen skeleton $(subst .skel.h,.bpf.legacy.o,$@) > $(subst .skel.h,.skel.legacy.h,$@)
+

--- a/test/strategy/README.md
+++ b/test/strategy/README.md
@@ -1,0 +1,5 @@
+# strategy tuner
+
+simple example showing Makefile and bpf/userspace portions of a
+tuner shared object that implements multiple strategies, switching
+between them.

--- a/test/strategy/strategy_tuner.bpf.c
+++ b/test/strategy/strategy_tuner.bpf.c
@@ -1,0 +1,58 @@
+/* SPDX-License-Identifier: GPL-2.0 WITH Linux-syscall-note */
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License v2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 021110-1307, USA.
+ */
+
+#include <bpftune/bpftune.bpf.h>
+
+/* fire when coredump sysctls are read */
+/* strategy A uses this BPF prog. */
+BPF_FENTRY(proc_dostring_coredump, struct ctl_table *table, int write,
+				   void *buffer, size_t *lenp, loff_t *ppos)
+{
+	struct bpftune_event event = {};
+	int ret, scenario_id = 0;
+
+	/* tuner id is a global declared in bpftune.bpf.h and set by bfttune
+	 * when the tuner is added.
+	 */
+	event.tuner_id = tuner_id;
+	event.scenario_id = scenario_id;
+	ret = bpf_ringbuf_output(&ring_buffer_map, &event, sizeof(event), 0);
+	bpftune_debug("tuner [%d] scenario [%d]: event send: %d ",
+		      tuner_id, scenario_id, ret);
+	return 0;
+}
+
+/* strategy B uses this BPF prog. */
+BPF_FENTRY(proc_dostring, struct ctl_table *table, int write,
+                                   void *buffer, size_t *lenp, loff_t *ppos)
+{
+	struct bpftune_event event = {};
+	int ret, scenario_id = 0;
+
+	/* tuner id is a global declared in bpftune.bpf.h and set by bfttune
+	 * when the tuner is added.
+	 */
+        event.tuner_id = tuner_id;
+        event.scenario_id = scenario_id;
+        ret = bpf_ringbuf_output(&ring_buffer_map, &event, sizeof(event), 0);
+	bpftune_debug("tuner [%d] scenario [%d]: event send: %d ",
+		      tuner_id, scenario_id, ret);
+	return 0;
+}
+

--- a/test/strategy/strategy_tuner.c
+++ b/test/strategy/strategy_tuner.c
@@ -1,0 +1,82 @@
+/* SPDX-License-Identifier: GPL-2.0 WITH Linux-syscall-note */
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License v2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 021110-1307, USA.
+ */
+
+#include <bpftune/libbpftune.h>
+#include <bpftune/bpftune.h>
+#include "strategy_tuner.skel.h"
+#include "strategy_tuner.skel.legacy.h"
+
+static int evaluate_A(struct bpftuner *tuner, struct bpftuner_strategy *strategy)
+{
+	if (tuner->strategy == strategy)
+		return 0;
+	else
+		return 1;
+}
+
+const char *progs_A[] = { "entry__proc_dostring_coredump", NULL };
+
+struct bpftuner_strategy strategy_A = {
+	.name		= "strategy_A",
+	.description	= "first strategy",
+	.evaluate	= evaluate_A,
+	.timeout	= 30,
+	.bpf_progs	= progs_A,
+};
+
+static int evaluate_B(struct bpftuner *tuner, struct bpftuner_strategy *strategy)
+{
+	if (tuner->strategy == strategy)
+		return 0;
+	else
+		return 1;
+}
+
+const char *progs_B[] = { "entry__proc_dostring", NULL };
+
+struct bpftuner_strategy strategy_B = {
+        .name           = "strategy_B",
+        .description    = "second strategy",
+        .evaluate       = evaluate_B,
+        .timeout        = 30,
+        .bpf_progs      = progs_B,
+};
+
+struct bpftuner_strategy *strategies[] = { &strategy_A, &strategy_B, NULL };
+
+int init(struct bpftuner *tuner)
+{
+	int err = bpftuner_strategies_add(tuner, strategies, &strategy_A);
+
+	if (err)
+		return err;
+	return bpftuner_bpf_init(strategy, tuner, NULL);
+}
+
+void fini(struct bpftuner *tuner)
+{
+	bpftuner_bpf_fini(tuner);
+}
+
+void event_handler(struct bpftuner *tuner, struct bpftune_event *event,
+		   __attribute__((unused))void *ctx)
+{
+	bpftune_log(LOG_DEBUG, "event  (scenario %d) for tuner %s, strategy %s\n",
+		    event->scenario_id, tuner->name, tuner->strategy->name);
+}

--- a/test/strategy_legacy_test.sh
+++ b/test/strategy_legacy_test.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/bash
+#
+# SPDX-License-Identifier: GPL-2.0 WITH Linux-syscall-note
+#
+# Copyright (c) 2023, Oracle and/or its affiliates.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public
+# License v2 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public
+# License along with this program; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 021110-1307, USA.
+#
+
+# run sysctl test
+
+. ./test_lib.sh
+
+
+SLEEPTIME=10
+
+
+test_start "$0|strategy legacy test: does strategy tuner appear, trigger event and change strategies?"
+
+test_setup "true"
+
+sleep 1
+test_run_cmd_local "$BPFTUNE -dsLl ./strategy &" true
+sleep $SETUPTIME
+# trigger event
+sysctl kernel.core_pattern
+sleep $SLEEPTIME
+grep -E "event .* for tuner strategy, strategy strategy_A" $TESTLOG_LAST
+sleep 30
+# trigger event
+sysctl kernel.core_pattern
+sleep $SLEEPTIME
+grep -E "event .* for tuner strategy, strategy strategy_B" $TESTLOG_LAST
+test_pass
+test_cleanup
+test_exit

--- a/test/strategy_test.sh
+++ b/test/strategy_test.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/bash
+#
+# SPDX-License-Identifier: GPL-2.0 WITH Linux-syscall-note
+#
+# Copyright (c) 2023, Oracle and/or its affiliates.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public
+# License v2 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public
+# License along with this program; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 021110-1307, USA.
+#
+
+# run sysctl test
+
+. ./test_lib.sh
+
+
+SLEEPTIME=10
+
+
+test_start "$0|strategy test: does strategy tuner appear, trigger event and change strategies?"
+
+test_setup "true"
+
+sleep 1
+test_run_cmd_local "$BPFTUNE -dsl ./strategy &" true
+sleep $SETUPTIME
+# trigger event
+sysctl kernel.core_pattern
+sleep $SLEEPTIME
+grep -E "event .* for tuner strategy, strategy strategy_A" $TESTLOG_LAST
+sleep 30
+# trigger event
+sysctl kernel.core_pattern
+sleep $SLEEPTIME
+grep -E "event .* for tuner strategy, strategy strategy_B" $TESTLOG_LAST
+test_pass
+test_cleanup
+test_exit


### PR DESCRIPTION
tuners can support multiple strategies; strategies should be set in the init() method via bpftune_strategies_add().  A strategy specifies a
 - name
 - description
 - timeout
 - evaluation function
 - set of bpf program names in tuner associated with strategy

The current strategy runs until timeout, then the evaluation functions for all strategies are called; we then switch to the strategy with the highest evaluation.  See tests/strategy for an example of a tuner implementing multiple strategies.